### PR TITLE
Does not work when inside join.

### DIFF
--- a/example.py
+++ b/example.py
@@ -23,18 +23,13 @@ def poolExample():
         pool.apply_async(run_worker)
 
     try:
-        print "Waiting 10 seconds"
-        time.sleep(10)
+        print "Waiting"
+        pool.close()
+        pool.join()
 
     except KeyboardInterrupt:
         print "Caught KeyboardInterrupt, terminating workers"
         pool.terminate()
-        pool.join()
-
-    else:
-        print "Quitting normally"
-        pool.close()
-        pool.join()
 
 
 class ConsumerProcess( multiprocessing.Process ):


### PR DESCRIPTION
This is not a fix, but rather the illustration of a problem.

In a real-life cenario, you would not wait 10 seconds, but actually join the pool and wait for all tasks to complete.

During this join call, KeyboardInterrupt will not be raised, and the program is unstoppable.
